### PR TITLE
Fix string error when loading clip models.

### DIFF
--- a/clip_text_decoder/common.py
+++ b/clip_text_decoder/common.py
@@ -54,10 +54,10 @@ class VisionBackbones(Enum):
     blip_base: str = "blip:base"
     clip_rn50: str = "clip:RN50"
     clip_rn101: str = "clip:RN101"
-    clip_vit_b32: str = "clip:VIT-B/32"
-    clip_vit_b16: str = "clip:VIT-B/16"
-    clip_vit_l14: str = "clip:VIT-L/14"
-    clip_vit_l14_336px: str = "clip:VIT-L/14@336px"
+    clip_vit_b32: str = "clip:ViT-B/32"
+    clip_vit_b16: str = "clip:ViT-B/16"
+    clip_vit_l14: str = "clip:ViT-L/14"
+    clip_vit_l14_336px: str = "clip:ViT-L/14@336px"
 
     @classmethod
     def list(cls):


### PR DESCRIPTION
**error**

The model name string ( `VIT-xxx` ) in the `check_vision_backbone` function is not compatible with the model name string ( `ViT-xxx` ) of the clip repository, which will cause at least one error in  `check_vision_backbone` function or when loading the clip model.

**solution**

In this PR, the model name string in the `check_vision_backbone` function is modified to `ViT-xxx` to make it compatible with the clip repository.